### PR TITLE
Detects the number of Kafka partitions for the give topic

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,7 @@
                  [org.onyxplatform/onyx-kafka "0.9.15.0"]
                  [org.onyxplatform/onyx-amazon-s3 "0.9.15.0"]
                  [com.stuartsierra/component "0.3.1"]
+                 [ymilky/franzy-admin "0.0.1" :exclusions [org.slf4j/slf4j-log4j12]]
                  [clj-time "0.10.0"]
                  [com.fasterxml.jackson.core/jackson-core "2.6.6"]
                  [com.cognitect/transit-clj "0.8.297"]

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -50,7 +50,6 @@
                                     :request-logging? true}}
  :job-config {:onyx-batch-size #long #or [#env ONYX_BATCH_SIZE 10]
               :onyx-batch-timeout #long #or [#env ONYX_BATCH_TIMEOUT 1000]
-              :kafka-topic-partitions #long #or [#env KAFKA_TOPIC_PARTITIONS 1]
               :kafka-topic #or [#env KAFKA_TOPIC "event"]
               :aws-region #or [#env AWS_REGION "eu-central-1"]
               :s3-bucket-name #or [#env S3_BUCKET_NAME "mc-witan-event-backup-staging"]}}


### PR DESCRIPTION
This means one less envar to set and also makes it more durable against
partition scaling (no need to re-deploy event2s3, just restart it)